### PR TITLE
Added bed occupancy column to oxygen dashboard

### DIFF
--- a/src/components/DistrictDashboard/OxygenMonitor.js
+++ b/src/components/DistrictDashboard/OxygenMonitor.js
@@ -5,7 +5,7 @@ import React, { lazy, Suspense, useMemo } from "react";
 import useSWR from "swr";
 
 import { careSummary } from "../../utils/api";
-import { OXYGEN_TYPES } from "../../utils/constants";
+import { OXYGEN_TYPES, AVAILABILITY_TYPES_OXYGEN } from "../../utils/constants";
 import {
   dateString,
   getNDateAfter,
@@ -178,9 +178,14 @@ function OxygenMonitor({ filterDistrict, filterFacilityTypes, date }) {
           Object.keys(c.inventory).length !== 0 &&
           (c.inventory[2] || c.inventory[4] || c.inventory[5] || c.inventory[6])
         ) {
+          const bedOccupency = AVAILABILITY_TYPES_OXYGEN.map(
+            (k) => c.capacity[k]?.current_capacity || 0
+          ).reduce((a, b) => a + b, 0);
+
           const arr = [
             [
               [c.name, c.facilityType, c.phoneNumber],
+              [bedOccupency],
               [c.oxygenCapacity],
               showStockWithBurnRate(c.inventory[2]),
               showStockWithBurnRate(c.inventory[4]),

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -30,6 +30,18 @@ export const AVAILABILITY_TYPES_ORDERED = [
   40,
 ];
 
+export const AVAILABILITY_TYPES_OXYGEN = [
+  10,
+  20,
+  50,
+  60,
+  70,
+  100,
+  110,
+  120,
+  150,
+];
+
 export const AVAILABILITY_TYPES = {
   20: "Ventilator",
   10: "ICU",
@@ -120,6 +132,7 @@ export const FACILITY_TYPES = [
 ];
 
 export const OXYGEN_TYPES = [
+  "Bed Occupancy",
   "Tank Capacity",
   "Oxygen Tank",
   "Cylinder D",


### PR DESCRIPTION
Added new column in the facilities table for Bed Occupancy in the oxygen dashboard. This resolves issue [#1024](https://github.com/coronasafe/care_fe/issues/1024) in care_fe