### PR TITLE
Make Table head to stick to top in sarafi

### DIFF
--- a/src/components/DistrictDashboard/GenericTable.js
+++ b/src/components/DistrictDashboard/GenericTable.js
@@ -76,7 +76,7 @@ function GenericTable({
         <div className="h-screen overflow-auto overscroll-auto">
           <table className="w-full">
             <TableHeader>
-              <tr className="sticky top-0 text-center whitespace-pre bg-gray-100 dark:bg-gray-700">
+              <tr className="top-0 text-center whitespace-pre bg-gray-100 dark:bg-gray-700">
                 {columns.map((item, i) => (
                   <th
                     className="sticky top-0 p-2 bg-gray-100 dark:bg-gray-700"


### PR DESCRIPTION
Fixes issue #134 
Now the table header sticks to the top in safari as well.
![image](https://user-images.githubusercontent.com/42417893/119967289-d2267700-bfc9-11eb-898d-d7e0517afc6a.png)
